### PR TITLE
브라우저 시간 검증 로직 제거

### DIFF
--- a/src/pages/Home/hooks/useCalendar.ts
+++ b/src/pages/Home/hooks/useCalendar.ts
@@ -80,7 +80,7 @@ const useCalendar = (userId: string) => {
     queryFn: () => fetchDate(),
   });
 
-  const today = todayData?.data === browseToday ? todayData?.data : 0;
+  const today = todayData?.data || browseToday;
 
   useEffect(() => {
     if (userCalendarData) {


### PR DESCRIPTION
기존에는 클라이언트 시간을 변경한다면 아예 서버시간과 관계없이 창문을 열지 못하게 해 두었습니다. 왜냐하면 클라이언트 시간을 바꾸는거 자체를 문제라고 생각하고 클라이언트 시간을 바꾸는 시점에서 창문을 막아 예외를 방지해야 한다고 생각했기 때문입니다.

하지만 미국 사람들은 브라우저 시간과 서버 시간이 달라서 서버시간이 26일이어도 브라우저 시간은 25일이고 서버시간이 26일이라 25일, 26일 모두 창문이 열리지 않는 문제가 발생했습니다.

그래서 브라우저 시간 검증 로직을 제외했습니다. 그래서 미국 사람들은 한국 시간 기준으로 창문을 열 수 있습니다.